### PR TITLE
Fixed incorrect page number for bibliography in index

### DIFF
--- a/Samples/clean/thesis.tex
+++ b/Samples/clean/thesis.tex
@@ -83,9 +83,11 @@
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %% Bibliography
 %%
+\cleardoublepage
+\phantomsection
+\addcontentsline{toc}{chapter}{Bibliography}
 \bibliographystyle{unsrt}
 \bibliography{thesis}
-\addcontentsline{toc}{chapter}{Bibliography}
 
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/thesis.tex
+++ b/thesis.tex
@@ -153,10 +153,11 @@ Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %% Bibliography:
 %%
-
+\cleardoublepage
+\phantomsection
+\addcontentsline{toc}{chapter}{Bibliography}
 \bibliographystyle{plain}
 \bibliography{thesis}
-\addcontentsline{toc}{chapter}{Bibliography}
 
 
 


### PR DESCRIPTION
The index showed the wrong page number for the bibliography (its last page instead of the first page), because "\addcontentsline{toc}{chapter}{Bibliography}" was placed after "\bibliography{...}".
Fixed this following http://tex.stackexchange.com/questions/8458/making-the-bibliography-appear-in-the-table-of-contents/98995#98995.