### PR TITLE
rename global option "index" into "withindex" to avoid clash

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ It also supports some custom options.
 
     _Note_: `glossaries` is the package used to create the glossary.
 
-*   `index`: build the index, which you can put at the and of the thesis with
+*   `withindex`: build the index, which you can put at the and of the thesis with
      the following command (it will create a new unnumbered chapter):
 
         \printthesisindex

--- a/cam-thesis.cls
+++ b/cam-thesis.cls
@@ -76,7 +76,7 @@
 % index - puts the index at the end of the thesis.
 %
 \newif\ifcam@index\cam@indexfalse
-\DeclareOption{index}{\cam@indextrue}
+\DeclareOption{withindex}{\cam@indextrue}
 
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/thesis.tex
+++ b/thesis.tex
@@ -15,13 +15,13 @@
 % Available documentclass options:
 %
 %   <all `report` document class options, e.g.: `a5paper`>
-%   index       - enables the index. New index entries can be added through `\index{my entry}`
+%   withindex   - enables the index. New index entries can be added through `\index{my entry}`
 %   glossary    - enables the glossary.
 %   techreport  - typesets the thesis in the technical report format.
 %   times       - uses the `Times` font.
 %
 % For more info see `README.md`
-\documentclass[index,glossary]{cam-thesis}
+\documentclass[withindex,glossary]{cam-thesis}
 
 
 


### PR DESCRIPTION
To fix #8: The "glossaries" package also defines an option called "index",
and if that is used, you can't load the "makeidx" and "glossaries"
packages at the same time, otherwise both will try to define \printindex.

The glossaries manual says:

> Either use glossaries for the indexing or use a custom indexing package,
> such as makeidx, index or imakeidx. (You can, of course, load one of
> those packages and load glossaries without the index package option.)".

Therefore, I propose to rename "index" into "withindex".