### PR TITLE
.travis.script.sh does not upload to BinTray by default.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,4 @@ addons:
     packages:
       - texlive
       - texlive-latex-extra
-script: source .travis.script.sh
+script: source .travis.script.sh --upload


### PR DESCRIPTION
Developers can now invoke `./.travis.script.sh` on their machines to perform exactly the same build as Travis CI would run.