### PR TITLE
Changing "Bibliography" to "References"

### DIFF
--- a/.circleci/tests/backrefs/thesis.tex
+++ b/.circleci/tests/backrefs/thesis.tex
@@ -67,9 +67,10 @@ This is a second reference so in Bibliography it is possible to see two differen
 
 
 
+\renewcommand{\bibname}{References}
 \cleardoublepage
 \phantomsection
-\addcontentsline{toc}{chapter}{Bibliography}
+\addcontentsline{toc}{chapter}{References}
 \bibliographystyle{plain}
 \bibliography{thesis}
 

--- a/.circleci/tests/backrefs/thesis.tex
+++ b/.circleci/tests/backrefs/thesis.tex
@@ -63,7 +63,7 @@ Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor 
 
 \marginpar[Margin note.]{Margin par.}
 
-This is a second reference so in Bibliography it is possible to see two different pages~\cite{example}.
+This is a second reference so in References it is possible to see two different pages~\cite{example}.
 
 
 

--- a/.circleci/tests/firstyr/thesis.tex
+++ b/.circleci/tests/firstyr/thesis.tex
@@ -89,9 +89,10 @@ Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor 
 
 
 
+\renewcommand{\bibname}{References}
 \cleardoublepage
 \phantomsection
-\addcontentsline{toc}{chapter}{Bibliography}
+\addcontentsline{toc}{chapter}{References}
 \bibliographystyle{plain}
 \bibliography{thesis}
 

--- a/.circleci/tests/secondyr/thesis.tex
+++ b/.circleci/tests/secondyr/thesis.tex
@@ -89,9 +89,10 @@ Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor 
 
 
 
+\renewcommand{\bibname}{References}
 \cleardoublepage
 \phantomsection
-\addcontentsline{toc}{chapter}{Bibliography}
+\addcontentsline{toc}{chapter}{References}
 \bibliographystyle{plain}
 \bibliography{thesis}
 

--- a/.circleci/tests/techreport/thesis.tex
+++ b/.circleci/tests/techreport/thesis.tex
@@ -89,9 +89,10 @@ Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor 
 
 
 
+\renewcommand{\bibname}{References}
 \cleardoublepage
 \phantomsection
-\addcontentsline{toc}{chapter}{Bibliography}
+\addcontentsline{toc}{chapter}{References}
 \bibliographystyle{plain}
 \bibliography{thesis}
 

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ thesis.log
 thesis.out
 thesis.pdf
 thesis.toc
+thesis.synctex.gz
 
 /build/
 /.idea/

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ It also supports some custom options.
 
     _Note_: the package `makeidx` is used to create the index.
 
-*   `backrefs`: Add back references in the Bibliography section (here's
+*   `backrefs`: Add back references in the References section (here's
     [a sample](https://dl.bintray.com/matej/thesis/backrefs-master.pdf)). In other words, for each reference, it adds the page(s) where it is cited.
 
     _Note_: the package `backref` is used to create the back references.

--- a/Samples/clean/01Preamble.tex
+++ b/Samples/clean/01Preamble.tex
@@ -47,7 +47,7 @@
 
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-%% Bibliography (special style etc.)
+%% References (special style etc.)
 %%
 \RequirePackage[numbers,sort&compress]{natbib}
 

--- a/Samples/clean/thesis.tex
+++ b/Samples/clean/thesis.tex
@@ -81,8 +81,12 @@
 
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-%% Bibliography
+%% References
 %%
+% If you include some work not referenced in the main text (e.g. using \nocite{}), consider changing "References" to "Bibliography".
+%
+
+% \renewcommand to change default "Bibliography" to "References"
 \renewcommand{\bibname}{References}
 \cleardoublepage
 \phantomsection

--- a/Samples/clean/thesis.tex
+++ b/Samples/clean/thesis.tex
@@ -83,9 +83,10 @@
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %% Bibliography
 %%
+\renewcommand{\bibname}{References}
 \cleardoublepage
 \phantomsection
-\addcontentsline{toc}{chapter}{Bibliography}
+\addcontentsline{toc}{chapter}{References}
 \bibliographystyle{unsrt}
 \bibliography{thesis}
 

--- a/thesis.tex
+++ b/thesis.tex
@@ -189,9 +189,10 @@ Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %% Bibliography:
 %%
+\renewcommand{\bibname}{References}
 \cleardoublepage
 \phantomsection
-\addcontentsline{toc}{chapter}{Bibliography}
+\addcontentsline{toc}{chapter}{References}
 \bibliographystyle{plainnat}
 \bibliography{thesis}
 

--- a/thesis.tex
+++ b/thesis.tex
@@ -187,8 +187,12 @@ Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor 
 
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-%% Bibliography:
+%% References:
 %%
+% If you include some work not referenced in the main text (e.g. using \nocite{}), consider changing "References" to "Bibliography".
+%
+
+% \renewcommand to change default "Bibliography" to "References"
 \renewcommand{\bibname}{References}
 \cleardoublepage
 \phantomsection


### PR DESCRIPTION
Hi,

While I was writing my thesis I've noticed that using "Bibliography" at the end is not technically correct, and that "References" should be used instead. To be more specific, "References" seems to be used when it only contains sources cited in the main text, while "Bibliography" is used when it also includes works that were not cited in the main text. These are some links I've googled with this info after discussing with some colleagues: 
https://studenthelp.secure.griffith.edu.au/app/answers/detail/a_id/1676/~/what-is-the-difference-between-a-reference-list-and-a-bibliography%3F
https://www.nottingham.ac.uk/studentservices/documents/whatarebibliographiesandreferences.pdf


Given that the current "Bibliography" is automatically generated when something is cited, I believe the default name should be "References" instead. If one wants to include something which is not cited, they need to manually change things in order to do that, which I believe is another reason to have "References" by default.

Happy to discuss this further, but here is the PR to start things already :)