### PR TITLE
upload built pdfs via the github upload-artifact action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,9 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Install Dependencies
-        run: sudo apt-get install -y python3 python3-boto3 texlive texlive-latex-extra
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y python3 python3-boto3 texlive texlive-latex-extra
 
       - name: Build
         env:
@@ -17,3 +19,9 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         run: |
             python3 .github/workflows/build.py
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: pdfs
+          path: build/samples/*/*.pdf


### PR DESCRIPTION
Built PDFs are now accessible through the "actions" UI.